### PR TITLE
fix bug when Tests were grouping under Test_Name other than under Test_Suite_Name

### DIFF
--- a/NUnitAllureAdapter/AllureEventListener.cs
+++ b/NUnitAllureAdapter/AllureEventListener.cs
@@ -178,7 +178,7 @@ namespace NUnitAllureAdapter
                 foreach (
                     Assembly asm in AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName.Contains(assembly)))
                 {
-                    foreach (Type type in asm.GetTypes().Where(x => x.Name.Contains(clazz)))
+                    foreach (Type type in asm.GetTypes().Where(x => x.Name.Equals(clazz)))
                     {
                         var manager = new AttributeManager(type.GetCustomAttributes(false).OfType<Attribute>().ToList());
                         manager.Update(evt);

--- a/NUnitAllureAdapter/AllureEventListener.cs
+++ b/NUnitAllureAdapter/AllureEventListener.cs
@@ -156,6 +156,7 @@ namespace NUnitAllureAdapter
                         });
                     }
                 }
+                AddAttachments(result);
                 WriteOutputToAttachment();
                 _lifecycle.Fire(new TestCaseFinishedEvent());
             }
@@ -261,6 +262,30 @@ namespace NUnitAllureAdapter
         private void TakeScreenshot()
         {
             _lifecycle.Fire(new MakeAttachmentEvent(AllureResultsUtils.TakeScreenShot(), "Screenshot", "image/png"));
+        }
+
+        private void AddAttachments(TestResult result)
+        {
+            if (result.Test.Properties.Contains("AllureAttachment"))
+            {
+                try
+                {
+                    string param = result.Test.Properties["AllureAttachment"] as string;
+                    string[] pathes = param.Split(',');
+                    foreach (string path in pathes)
+                    {
+                        FileInfo file = new FileInfo(path);
+                        _lifecycle.Fire(new MakeAttachmentEvent(
+                            File.ReadAllBytes(path), file.Name, MimeTypes.ToMime(file.Extension)));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _stdErr.Append(string.Format("Exception type: \"{0}\". Message: \"{1}\".", ex.GetType(), ex.Message));
+                    if (ex.InnerException != null)
+                        _stdErr.Append(string.Format("\tInnerExceptionType: \"{0}\". InnerExceptionMessage: \"{1}\".", ex.InnerException.GetType(), ex.InnerException.Message));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Found a bug again, when test with name Ora() with several Test Cases were grouping under [assembly].[test_suite].Ora other then under [assembly].[test_suite]
Was caused by using Contains() method when finding a type in the assembly with the name of the test. In my case for Ora test it found some *Oracle* class name and marked whole [assembly].[test_suite].Ora as a separate test suite.
I think Equals() is more appropriate here.